### PR TITLE
Replaced vprintf on vsprintf  in GitRepo::run(); added commit message in GitRepo::merge()

### DIFF
--- a/src/Coyl/Git/GitRepo.php
+++ b/src/Coyl/Git/GitRepo.php
@@ -210,7 +210,7 @@ class GitRepo
     {
         if (is_null($parameters))
             $parameters = [];
-        return $this->console->runCommand(vprintf(Git::getBin() . " " . $command, $parameters));
+        return $this->console->runCommand(vsprintf(Git::getBin() . " " . $command, $parameters));
     }
 
     /**

--- a/src/Coyl/Git/GitRepo.php
+++ b/src/Coyl/Git/GitRepo.php
@@ -468,12 +468,16 @@ class GitRepo
      *
      * @access  public
      * @param   string $branch branch name
+     * @param   string $message commit message (optional)
      * @return  string
      */
-    public function merge($branch)
+    public function merge($branch, $message = null)
     {
         $branch = escapeshellarg($branch);
-        return $this->run("merge %s --no-ff", [$branch]);
+        if (null !== $message) {
+            $message = sprintf('-m "%s"', trim($message));
+        }
+        return $this->run("merge %s --no-ff %s", [$branch, $message]);
     }
 
     /**


### PR DESCRIPTION
1. Fixed bug:
   Vprintf returns the length of the outputted string (http://no1.php.net/manual/en/function.vprintf.php)
   Need use vsprintf (http://no1.php.net/manual/ru/function.vsprintf.php)
2. Added commit message in GitRepo::merge()
